### PR TITLE
Fixed link.

### DIFF
--- a/src/pages/home.vue
+++ b/src/pages/home.vue
@@ -49,7 +49,7 @@ export default Vue.component('resume', {
 });
 </script>
 
-<style scoped>
+<style lang="less" scoped>
 .home {
   font-family: 'Roboto' !important;
 }
@@ -91,29 +91,27 @@ export default Vue.component('resume', {
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
   height: 252px;
   overflow: hidden;
+  img {
+    width: 100%;
+    opacity: 0.5;
+    filter: blur(1px);
+  }
+  span {
+    position: absolute;
+    max-width: 100%;
+    font-size: 24px;
+    font-weight: 300;
+    color: rgba(0, 0, 0, 0.75);
+    width: 100%;
+    text-align: center;
+    display: inline-block;
+    top: 50%;
+    transform: translateY(-50%);
+  }
 }
 
 .preview-wrapper {
   position: relative;
   background: white;
-}
-
-.preview img {
-  width: 100%;
-  opacity: 0.5;
-  filter: blur(1px);
-}
-
-.preview span {
-  position: absolute;
-  max-width: 100%;
-  font-size: 24px;
-  font-weight: 300;
-  color: rgba(0, 0, 0, 0.75);
-  width: 100%;
-  text-align: center;
-  display: inline-block;
-  top: 50%;
-  transform: translateY(-50%);
 }
 </style>

--- a/src/resumes/left-right.vue
+++ b/src/resumes/left-right.vue
@@ -25,11 +25,11 @@
       <h3>Contact</h3>
       <table>
         <tr>
-          <td><a :href="'mailto:'+person.contact.email">{{person.contact.email}}</a></td>
+          <td><a :href="`mailto:${person.contact.email}`">{{person.contact.email}}</a></td>
           <td><i class="fa fa-envelope" aria-hidden="true"></i></td>
         </tr>
         <tr>
-          <td><a :href="'tel:'+person.contact.phone">{{person.contact.phone}}</a></td>
+          <td><a :href="`tel:${person.contact.phone}`">{{person.contact.phone}}</a></td>
           <td><i class="fa fa-phone" aria-hidden="true"></i></td>
         </tr>
         <tr>
@@ -41,7 +41,7 @@
           <td><i class="fa fa-globe" aria-hidden="true"></i></td>
         </tr>
         <tr>
-          <td><a :href="'https://github.com/'+person.contact.github">https://github.com/{{person.contact.github}}</a></td>
+          <td><a :href="githubLink">{{githubLink}}</a></td>
           <td><i class="fa fa-github" aria-hidden="true"></i></td>
         </tr>
       </table>
@@ -60,7 +60,7 @@
       <div class="skill-block" v-for="skill in person.skills">
         <span class="skill">{{skill.name}}</span>
         <div class="skill-bar">
-          <div :style="'width: '+skill.level+'%'" class="level"> </div>
+          <div :style="{'width': `${skill.level}%`}" class="level"> </div>
         </div>
       </div>
     </div>
@@ -77,6 +77,11 @@ import {
 import Vue from 'vue';
 export default Vue.component('left-right', {
   name: 'left-right',
+  computed: {
+    githubLink: function () {
+      return `https://github.com/${this.person.contact.github}`;
+    }
+  },
   data () {
     return {
       person: PERSON

--- a/src/resumes/material-dark.vue
+++ b/src/resumes/material-dark.vue
@@ -30,7 +30,7 @@
       </div>
     </div>
 
-    <a :href="'tel:'+person.contact.phone">
+    <a :href="`tel:${person.contact.phone}`">
       <div class="item">
         <div class="icon">
           <i class="material-icons">phone</i>
@@ -41,7 +41,7 @@
       </div>
     </a>
 
-    <a :href="'mailto:'+person.contact.email">
+    <a :href="`mailto:${person.contact.email}`">
       <div class="item">
         <div class="icon">
           <i class="material-icons">email</i>
@@ -83,7 +83,7 @@
         <div class="right">
           <span>{{skill.name}}&nbsp;</span>
           <div class="progress">
-            <div class="determinate" :style="'width: '+skill.level+'%;'">
+            <div class="determinate" :style="{'width': `${skill.level}%`}">
               <i class="fa fa-circle"></i>
             </div>
           </div>

--- a/src/resumes/oblique.vue
+++ b/src/resumes/oblique.vue
@@ -56,17 +56,16 @@
     </div>
     <div class="contact">
       <h3>Contact</h3>
-      <a :href="'mailto:'+person.contact.email"> {{person.contact.email}}</a>
+      <a :href="`mailto:${person.contact.email}`"> {{person.contact.email}}</a>
       <span>;&nbsp;</span>
-      <a :href="'tel:'+person.contact.phone">{{person.contact.phone}}</a>
+      <a :href="`tel:${person.contact.phone}`">{{person.contact.phone}}</a>
       <span>;&nbsp;</span>
       <span>{{person.contact.street}}, {{person.contact.city}}</span>
       <span>;&nbsp;</span>
       <a :href="person.contact.website">
               {{person.contact.website}}</a>
       <span>;&nbsp;</span>
-      <a :href="'https://github.com/'+person.contact.github">
-                https://github.com/{{person.contact.github}}</a>
+      <a :href="githubLink">{{githubLink}}</a>
     </div>
   </div>
 </div>
@@ -80,6 +79,11 @@ import {
 import Vue from 'vue';
 export default Vue.component('oblique', {
   name: 'oblique',
+  computed: {
+    githubLink: function () {
+      return `https://github.com/${this.person.contact.github}`;
+    }
+  },
   data () {
     return {
       person: PERSON

--- a/src/resumes/side-bar.vue
+++ b/src/resumes/side-bar.vue
@@ -1,8 +1,12 @@
 <template>
   <div id="resume2" class="resume">
       <div class="top-row">
-          <span class="person-name">{{person.name.first}}  {{person.name.last}}</span>
-          <span class="person-position">{{person.position}}</span>
+          <span class="person-name">
+            {{person.name.first}} {{person.name.middle}} {{person.name.last}}
+          </span>
+          <span class="person-position">
+            {{person.position}}
+          </span>
       </div>
       <div class="left-col">
           <div class="person-image">

--- a/src/resumes/side-bar.vue
+++ b/src/resumes/side-bar.vue
@@ -1,8 +1,8 @@
 <template>
   <div id="resume2" class="resume">
       <div class="top-row">
-          <span class="person-name">  {{person.name.first}}  {{person.name.last}}    </span>
-          <span class="person-position">  {{person.position}}    </span>
+          <span class="person-name">{{person.name.first}}  {{person.name.last}}</span>
+          <span class="person-position">{{person.position}}</span>
       </div>
       <div class="left-col">
           <div class="person-image">
@@ -13,7 +13,7 @@
           <div class="contact">
               <h3>Contact</h3>
               <div class="contact-row">
-                  <a :href="'mailto:'+person.contact.email">{{person.contact.email}}</a>
+                  <a :href="`mailto:${person.contact.email}`">{{person.contact.email}}</a>
               </div>
               <div class="contact-row dots">
                   <i class="fa fa-circle" aria-hidden="true"></i>
@@ -21,7 +21,7 @@
                   <i class="fa fa-circle" aria-hidden="true"></i>
               </div>
               <div class="contact-row">
-                  <a href="'tel:'+person.contact.phone">{{person.contact.phone}}</a>
+                  <a :href="`tel:${person.contact.phone}`">{{person.contact.phone}}</a>
               </div>
               <div class="contact-row dots">
                   <i class="fa fa-circle" aria-hidden="true"></i>
@@ -37,7 +37,7 @@
                   <i class="fa fa-circle" aria-hidden="true"></i>
               </div>
               <div class="contact-row">
-                  <a :href="'https://github.com/'+person.contact.github">https://github.com/{{person.contact.github}}</a>
+                  <a :href="githubLink">{{githubLink}}</a>
               </div>
           </div>
       </div>
@@ -71,15 +71,13 @@
           <div class="skills-block">
               <h3>Skills</h3>
               <div class="skills">
-                      <div class="skill" v-for="skill in person.skills">
-                          <span class="skill-name">{{skill.name}}</span>
-                      </div>
+                  <div class="skill" v-for="skill in person.skills">
+                      <span class="skill-name">{{skill.name}}</span>
+                  </div>
               </div>
               <span class="skills-other"> {{person.skillDescription}} </span>
           </div>
       </div>
-  </div>
-
   </div>
 </template>
 
@@ -91,6 +89,11 @@ import {
 import Vue from 'vue';
 export default Vue.component('side-bar', {
   name: 'side-bar',
+  computed: {
+    githubLink: function () {
+      return `https://github.com/${this.person.contact.github}`;
+    }
+  },
   data () {
     return {
       person: PERSON


### PR DESCRIPTION
I think you should define a method or somethings for using all templates.
Eg. githubLink => return `https://github.com/${this.person.contact.github}`

and using ${} instead default style.
Eg: 'sametext' + property'

This is just temporary. I will seen new pull request replace this method.

<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

## This PR contains:
<!--
 - IMPROVED DOCS
 - A TYPO-FIX
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->

## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->

<!--

IMPORTANT: READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- DO NOT ADD GENERATED FILES TO THE PULL-REQUEST (NOTHING FROM THE pdf-FOLDER)

-->
